### PR TITLE
[Community Skill] Add MackDing agent skills

### DIFF
--- a/community/ai-native-founder-playbook/SKILL.md
+++ b/community/ai-native-founder-playbook/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: ai-native-founder-playbook
+description: >
+  Apply a bilingual AI-native startup operating playbook for founder strategy,
+  MVP scoping, launch operations, GTM planning, and PMF diagnostics.
+  Trigger: When evaluating startup ideas, planning an MVP, designing founder
+  workflows, or converting startup strategy into agent-executable work.
+metadata:
+  author: MackDing
+  version: "1.0"
+---
+
+## When to Use
+
+Use this skill when the user needs practical startup operating help rather than generic advice:
+
+- Validate an AI-native startup idea before building.
+- Convert founder intuition into explicit assumptions, tests, and stage gates.
+- Scope an MVP so coding agents do not build a broad platform too early.
+- Diagnose PMF, launch operations, GTM motion, founder bottlenecks, or data flywheels.
+- Prepare agent workflows for research, coding, publishing, review, and metrics loops.
+
+Canonical source: <https://github.com/MackDing/ai-native-founder-playbook-skill>
+
+## Critical Patterns
+
+### Separate Facts, Assumptions, And Tests
+
+Do not let the agent turn founder excitement into certainty. Split the plan into what is known, what is assumed, and what would prove or disprove the assumption.
+
+```markdown
+## Startup Hypothesis
+
+- Fact: The founder has access to 30 target users in the niche.
+- Assumption: These users lose more than 3 hours per week on the workflow.
+- Risk: The pain may be inconvenient but not budget-worthy.
+- Test: Interview 10 users and ask for recent examples, current workaround, and willingness to pre-order.
+- Kill criterion: Fewer than 3 users describe a recent high-cost failure.
+```
+
+### Stage-Gate Before Build Scope
+
+Always identify whether the company is in idea, MVP, launch, or scale mode before recommending work. The same feature can be useful at scale and wasteful at idea stage.
+
+```markdown
+## Stage Gate
+
+Stage: MVP
+Goal: Prove one repeated workflow can be completed faster with the product.
+Do now: Build one high-frequency path with manual review.
+Defer: Marketplace, team roles, generic workflow builder, broad integrations.
+Exit criterion: 5 users complete the workflow twice without founder handholding.
+```
+
+### Convert Strategy Into Agent Workflows
+
+End with concrete work packets a founder can delegate to research, coding, automation, or review agents.
+
+```markdown
+## Agent Work Packets
+
+1. Research agent: collect 20 recent examples of the user's current workaround.
+2. Coding agent: implement only the single ingest -> transform -> review path.
+3. Automation agent: publish usage events to a weekly PMF dashboard.
+4. Human review: inspect failed cases before expanding scope.
+```
+
+## Code Examples
+
+### Example 1: MVP Scope Prompt
+
+```text
+Use ai-native-founder-playbook to convert this idea into a wedge-first MVP.
+Return: stage, riskiest assumptions, excluded features, 2-week build scope,
+and 5 exit criteria. Do not propose a platform unless the evidence requires it.
+```
+
+### Example 2: PMF Diagnostic Prompt
+
+```text
+Use ai-native-founder-playbook to diagnose PMF from these interviews and metrics.
+Separate retention, urgency, willingness to pay, switching cost, and founder bias.
+List the strongest disconfirming evidence first.
+```
+
+### Example 3: Agent Workflow Prompt
+
+```text
+Use ai-native-founder-playbook to split this launch plan into agent work packets:
+research, coding, content, publishing, data reflow, and weekly review.
+Each packet needs inputs, outputs, owner, and verification.
+```
+
+## Anti-Patterns
+
+### Don't: Build A Broad Platform From A Vague Problem
+
+Avoid turning an early idea into a large product surface before a specific workflow and buyer pain are verified.
+
+```text
+Bad: Build dashboards, integrations, user roles, API, templates, and marketplace.
+Good: Build one workflow for one user type and verify repeated use.
+```
+
+### Don't: Hide Missing Evidence
+
+If the founder has no interviews, no usage data, or no buyer signal, say that directly and design the next test.
+
+```text
+Bad: "This market looks promising, so build the MVP."
+Good: "The plan depends on unverified urgency. Run 10 interviews before coding."
+```
+
+## Quick Reference
+
+| Task | Pattern |
+|------|---------|
+| Validate an idea | `facts -> assumptions -> tests -> kill criteria` |
+| Scope an MVP | `stage -> wedge -> excluded features -> exit criteria` |
+| Delegate to agents | `research -> coding -> automation -> human review` |
+
+## Resources
+
+- Source repository: <https://github.com/MackDing/ai-native-founder-playbook-skill>
+- ClawHub listing: <https://clawhub.ai/mackding/ai-native-founder-playbook>

--- a/community/karpathy-coding-guidelines-zh/SKILL.md
+++ b/community/karpathy-coding-guidelines-zh/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: karpathy-coding-guidelines-zh
+description: >
+  Apply Chinese AI coding-agent rules inspired by Andrej Karpathy's guidance:
+  think before coding, keep changes simple, scope diffs precisely, and verify.
+  Trigger: When using Claude Code, Codex, Cursor, or other coding agents in
+  Chinese-language projects or teams that need safer coding behavior.
+metadata:
+  author: MackDing
+  version: "1.0"
+---
+
+## When to Use
+
+Use this skill when an AI coding agent needs clearer engineering behavior rules:
+
+- The user is working in Chinese and wants project-level coding-agent guidelines.
+- A task risks over-engineering, unrelated refactors, hidden assumptions, or unverifiable changes.
+- A project needs reusable `CLAUDE.md`, `AGENTS.md`, Cursor Rules, or skill-style instructions.
+- A reviewer wants the agent to keep diffs small and explain tradeoffs before editing.
+
+Canonical source: <https://github.com/MackDing/andrej-karpathy-skills-zh>
+
+## Critical Patterns
+
+### Think Before Coding
+
+State assumptions, ambiguity, and tradeoffs before changing files. If the requirement is unclear, ask before inventing scope.
+
+```markdown
+## Before Editing
+
+- Goal: Fix the login timeout error.
+- Assumption: The timeout comes from the API client retry loop, not the UI.
+- Risk: Changing global fetch behavior may affect unrelated requests.
+- Plan: Add a narrow timeout override only for login and verify with the existing auth tests.
+```
+
+### Keep The Smallest Working Diff
+
+Prefer the smallest change that solves the problem. Do not add abstractions, new packages, or broad rewrites unless the local codebase already points there.
+
+```diff
+- replace the entire auth module
++ add a bounded retry option to the existing login request
++ add one regression test for timeout behavior
+```
+
+### Verify Before Claiming Completion
+
+The agent must run the relevant checks or clearly state what could not be run. A claim without verification is not finished work.
+
+```bash
+npm test -- auth-timeout.test.ts
+npm run lint
+git diff --check
+```
+
+## Code Examples
+
+### Example 1: Codex `AGENTS.md` Rule
+
+```markdown
+Before editing, identify the smallest module that owns the behavior.
+Do not refactor unrelated files. After editing, run the narrowest relevant test
+and report the command and result.
+```
+
+### Example 2: Claude Code `CLAUDE.md` Rule
+
+```markdown
+When requirements are ambiguous, stop and expose the ambiguity in Chinese.
+List at most three interpretations and recommend the safest default.
+Only proceed without asking when one option is clearly implied by existing code.
+```
+
+### Example 3: Cursor Rule
+
+```markdown
+---
+description: Keep AI coding changes scoped and verifiable
+globs: ["**/*"]
+alwaysApply: true
+---
+
+Prefer precise diffs. Do not introduce new architecture for a local bug fix.
+Use existing helpers and tests before adding new patterns.
+```
+
+## Anti-Patterns
+
+### Don't: Hide Assumptions
+
+```text
+Bad: "I'll update the auth flow" while silently changing routing and session storage.
+Good: "I am assuming the timeout is login-specific; I will only edit the login request."
+```
+
+### Don't: Turn A Bug Fix Into A Rewrite
+
+```text
+Bad: Replace the data layer, rename files, and migrate unrelated code.
+Good: Patch the failing branch and add one focused regression test.
+```
+
+## Quick Reference
+
+| Task | Pattern |
+|------|---------|
+| Ambiguous request | `assumptions -> options -> safest recommendation` |
+| Bug fix | `smallest owner -> focused patch -> regression test` |
+| Completion | `commands run -> result -> residual risk` |
+
+## Resources
+
+- Source repository: <https://github.com/MackDing/andrej-karpathy-skills-zh>

--- a/community/skill-usage-monitor/SKILL.md
+++ b/community/skill-usage-monitor/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: skill-usage-monitor
+description: >
+  Monitor and analyze AI agent skill calls with the Skill Usage dashboard for
+  OpenClaw, Hermes-Agent, Claude Code, Codex, and JSONL-based agents.
+  Trigger: When diagnosing redundant skills, slow skills, failed skill calls,
+  or unclear skill usage across agent sessions.
+metadata:
+  author: MackDing
+  version: "1.0"
+---
+
+## When to Use
+
+Use this skill when the user wants operational visibility into skills:
+
+- Find which skills are called most often and whether they are useful.
+- Detect slow, failing, idle, or redundant skills.
+- Monitor Codex, Claude Code, OpenClaw, Hermes-Agent, or any JSONL-based session logs.
+- Prepare before pruning or reorganizing a large skill library.
+- Demo skill usage behavior in a lightweight local dashboard.
+
+Canonical source: <https://github.com/MackDing/skill-usage>
+
+## Critical Patterns
+
+### Start With A Read-Only Watch
+
+Point the dashboard at a copy or read-only session directory first. Do not mutate agent logs while analyzing usage.
+
+```bash
+git clone https://github.com/MackDing/skill-usage.git
+cd skill-usage
+node src/server.mjs --watch ./sessions
+```
+
+### Compare Frequency With Failure Rate
+
+High call volume is not always good. Prioritize skills that are frequent and failing, slow, or idle after install.
+
+```text
+Review order:
+1. Failed calls by skill
+2. P95 latency by skill
+3. High-frequency skills with low completion value
+4. Skills installed but never triggered
+```
+
+### Keep Monitoring Lightweight
+
+Use the zero-dependency server and JSONL persistence. Avoid adding a database or complex telemetry pipeline until the questions require it.
+
+```bash
+node src/server.mjs --watch ~/.codex/sessions
+# Open http://localhost:3456
+```
+
+## Code Examples
+
+### Example 1: Monitor A Codex Session Folder
+
+```bash
+node src/server.mjs --watch ~/.codex/sessions
+```
+
+### Example 2: Monitor A Project-Local Log Folder
+
+```bash
+node src/server.mjs --watch ./logs/agent-sessions
+```
+
+### Example 3: Use Demo Data For A Review
+
+```bash
+node src/server.mjs --demo
+```
+
+## Anti-Patterns
+
+### Don't: Prune Skills From Raw Frequency Alone
+
+```text
+Bad: Delete every low-frequency skill.
+Good: Check whether the skill is specialized, recently added, or critical for rare high-value tasks.
+```
+
+### Don't: Treat Browser Success As Agent Success
+
+```text
+Bad: Assume a dashboard showing events means all skills are working.
+Good: Inspect failures, latency, session paths, and whether expected JSONL events are actually parsed.
+```
+
+## Quick Reference
+
+| Task | Pattern |
+|------|---------|
+| Find bad skills | `failure rate -> latency -> useless frequency` |
+| Start monitoring | `node src/server.mjs --watch <session-dir>` |
+| Reduce risk | `read-only copy -> inspect -> prune intentionally` |
+
+## Resources
+
+- Source repository: <https://github.com/MackDing/skill-usage>


### PR DESCRIPTION
## Community Skill Submission

### Skill Name
AI-Native Founder Playbook; Karpathy Coding Guidelines ZH; Skill Usage Monitor

### Description
Adds three community skills maintained by MackDing:
- AI-native founder strategy and workflow playbook
- Chinese coding-agent guidelines for Claude Code, Codex, Cursor, and related agents
- Skill usage monitoring workflow for JSONL-based agent skill calls

### Why This Skill?
These skills cover practical gaps for founder workflows, safer coding-agent behavior in Chinese teams, and operational visibility into skill usage and failures.

### Checklist

- [x] Skill is in the `community/` folder
- [x] Includes `SKILL.md` with proper structure
- [x] Has clear trigger conditions
- [x] Includes at least 3 code examples
- [x] Lists anti-patterns to avoid
- [x] Tested with Claude Code or OpenCode
- [x] Not a duplicate of existing skills

### Framework/Library Version
Agent Skills / Claude Code / Codex compatible markdown skill format.

### Testing
Validated structure locally against the repository requirements: YAML frontmatter, trigger descriptions, When to Use, Critical Patterns, Code Examples, and markdown-only allowed files.

---

## Voting

Community members: Please vote using reactions!

- **Approve** - Use any positive reaction (thumbs up, heart, rocket, etc.)
- **Reject** - Use thumbs down reaction

Voting period: **7 days** from PR creation.
