### PR TITLE
fix: typo in Community Skills section

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Skills contributed by the community and approved through our voting process.
 | Skill | Description | Author |
 |-------|-------------|--------|
 | [electron](community/electron) | Electron patterns for building cross-platform desktop applications. | @gentleman-programming |
-| [elixir-antipatterns](community/elixir-antipatterns) | Core catalog of 8 critical Elixir/Phoenix anti-patterns covering error handli... | @tsardinasGitHub |
+| [elixir-antipatterns](community/elixir-antipatterns) | Core catalog of 8 critical Elixir/Phoenix anti-patterns covering error handling... | @tsardinasGitHub |
 | [hexagonal-architecture-layers-java](community/hexagonal-architecture-layers-java) | Hexagonal architecture layering for Java services with strict boundaries. | @diegnghrmr |
 | [java-21](community/java-21) | Java 21 language and runtime patterns for modern, safe code. | @diegnghrmr |
 | [react-native](community/react-native) | React Native patterns for mobile app development with Expo and bare workflow. | @gentleman-programming |


### PR DESCRIPTION
Fix minor typo in README.md

Changed "error handli" to "error handling" in the Community Skills section of the README file.